### PR TITLE
Add various steppers, update database, Fix for node22 update

### DIFF
--- a/data/steppers.csv
+++ b/data/steppers.csv
@@ -1,16 +1,28 @@
 Brand	Model	NEMA	Body Length (mm)	Step Angle (deg)	Rated Current (A)	Holding Torque (N-cm)	Inductance (mH)	Resistance (ohms)	Rotor Inertia (g-cm^2)	Comments (semicolon separated)
 KeliMotor	BJ42D41-14V19	17	60	1,8	2	65	2,8	1,1	128	Preinstalled with GT2 pulley; ELEGOO Centauri A/B; https://s3.devminer.xyz/archive/BJ42D41-14V19%20drawing.pdf
+KeliMotor	BJ42D41-Y2V01	17	59	1,8	1.5	80	6,9	3	110
+KeliMotor	BJ42D41-Y3V01	17	59	1,8	2	72	3,7	1,8	110
+KeliMotor	BJ42D41-Y4V01	17	59	1,8	2.5	80	2,4	1	110
 KeliMotor	BJ42D22-25V04	17	40	1,8	1,2	40	6	2,9	57	Preinstalled with GT2 pulley; ELEGOO Centauri Z; https://s3.devminer.xyz/archive/BJ42D22-25V04%20drawing.pdf
+KeliMotor	BJ42D22-23V01	17	40	1,8	1,0	37	6,9	2,8	57	https://s3.devminer.xyz/archive/KeliMotor_BJ42D22-23V01.png
 KeliMotor	BJY36D12-04V28	14	20,5	1,8	1,2	10	1,2	2,0	17	Preinstalled Involute 10T gear (0.5mm modulus, 20deg pressure angle); ELEGOO Centauri Extruder; https://s3.devminer.xyz/archive/BJY36D12-04V28%20drawing.pdf
+KeliMotor	BJY36D12-04V01	14	20,5	1,8	1	11	1,3	2,0	17	Bambulab X1/P1 extruder; 9T helical gear
+KeliMotor	BJY36d13-01V01	14	20	1.8	1,0	19	3.4	3.2	11	12T pinion gear; Creality K1 series extruder; https://s3.devminer.xyz/archive/Creativity_BJY36d13-01V01.webp
 KeliMotor	BJ42D29-100V02	17	48	1,8	2,0	45	1,9	1,1	76	Bambulab X1/P1 A/B; https://s3.devminer.xyz/archive/BJ42D29-100V02%20drawing.pdf
 KeliMotor	BJ42D22-23V47	17	40	1,8	1,0	37	6,9	2,8	57	Bambulab X1/P1 Z; https://s3.devminer.xyz/archive/BJ42D22-24V47%20drawing.pdf
 KeliMotor	BJ42D29-28V17	17	48	1,8	1,5	41	2,6	1,4	76	QIDI Plus 4 A/B; Preinstalled with GT1.5 pulley
 KeliMotor	BJY36D15-01V01	14	20,5	1,8	1	22	5	4,3	31	
-KeliMotor	BJ42D15-26V12	17	34	1,8	0,84	28	8,8	6	38	Ender 3 S1 (and more, probably)
+KeliMotor	BJ42D15-26V02	17	34	1,8	0,84	28	8.8	6	38	https://s3.devminer.xyz/archive/KeliMotor_BJ42D15-26V02%20drawing.pdf
+KeliMotor	BJ42D15-26V09	17	34	1,8	0,84	38	8.8	6	38	Apparently identical to BJ42D16-26V09; https://s3.devminer.xyz/archive/KeliMotor_BJ42D15-26V09.png
+KeliMotor	BJ42D15-26V10	17	34	1,8	0,84	28	8.8	6	38	Preinstalled with GT2 pulley; https://s3.devminer.xyz/archive/KeliMotor_BJ42D15-26V10.pdf
+KeliMotor	BJ42D15-26V12	17	34	1,8	0,84	38	8,8	6	38	Ender 3 S1 (and more, probably)
+KeliMotor	BJ42D16-26V09	17	34	1,8	0,84	38	8.8	6	57	Apparently identical to BJ42D15-26V09
 KeliMotor	BJ42D09-20V02	17	26	1,8	0,84	15	3	1,75	30	Creality Sprite Extruder
 KeliMotor	BJ42D29-76V01	17	48	1,8	4	56	0,7	0,4	76	FLSun T1 Pro A/B/C; Preinstalled with GT2 30T pulley; https://s3.devminer.xyz/archive/BJ42D29-76V01%20Drawing.pdf
+Creativity	BJ42D29-100V02	14	20	1,8	1	12	1	2,3	16	Bambulab X1/P1 extruder replacement; 9T helical gear; most motors with four screws in the front plate appear to be this model
+Twotrees	36STH20-1004HG	14	22	1.8	1,0	10	1.6	2.1	16	Sketchy motor sold for VORONS with similar P/N to LDO 36STH20-1004(A/HG)
 ACT	17HS5425	17	48	1,8	2,5	48	1,9	1,2	68	Seem to be clones/rebadges of Wantai 42BYGHW811
-ACT	17HS5425-06	17	48	1,8	2,5	60	1,75	1	68  Seem to be clones/rebadges of Wantai 42BYGHW811-06
+ACT	17HS5425-06	17	48	1,8	2,5	60	1,75	1	68	Seem to be clones/rebadges of Wantai 42BYGHW811-06
 ACT	17HS6416D6L22P5.5-12	17	60	1,8	1,6	70	6	2,2	102
 ACT	17HM3404	17	33	0,9	0,4	20	18,5	7,8	35
 ACT	17HM3412	17	33	0,9	1,2	23	5,2	2,7	35
@@ -29,9 +41,13 @@ ACT	17HS5413	17	48	1,8	1,3	52	5,5	3,2	68
 ACT	17HS6415-D	17	57	1,8	1,5	70	6,5	2,5	102
 ACT	17HS6409	17	60	1,8	0,86	70	11,45	4,94	95
 ACT	17HS6423-C	17	64	1,8	2,3	70	2,57	1,38	110
+ACT	36HS20HM-1884A	14	19	1.8	1,88	13	1,05	1,85	6	often sold in VORON extruder kits; may be identified as 36HS2418CL16, or 36HS2418CL6; https://s3.devminer.xyz/archive/Maccurat_36HS20HM-1884A.avif
+ACT	36BYG1204-A-6QHT	14	22	1.8	0,5	12	1	1,3	15	often sold in VORON extruder kits; https://s3.devminer.xyz/archive/ACT_36BYG1204-A-6QHT.webp
+ACT	36BYG1103-3M-8QH	14	20	1.8	1	11	1,0	1,3	17 Bambulab X1/P1 extruder; 9T helical gear, common replacement part with two screws in front plate
 FYSETC	35HSH7402-24B-400A	14	51	1,8	1,5	42	5,5	2,8	48
 FYSETC	42HSC1404B-200N8	14	34,5	1,8	0,4	32	38	29	40
 FYSETC	G36HSY4407-6D-550	14	20,5	1,8	0,5	12	10	13	15
+FYSETC	G36HSY4405-6DB-1000A	14	20.5	1,8	1	11	1.7	2.4	15	Appears to ship with IdeaFormer space V2 extruder, likely others; not labelled as FYSETC but likely is; https://s3.devminer.xyz/archive/FYSETC_G36HSY4405-6DB-1000A.webp
 FYSETC	MSM-30010-R0005	17	20	1,8	1	14	3,6	4,1	
 FYSETC	TB-3544	17	39	1,8	1,5	50	3,8	1,8	55
 FYSETC	17HS19-2004S-C	17	48	1,8	2	59	3	1,4	82
@@ -47,6 +63,9 @@ LDO	42STH40-1684AC	17	40	1,8	1,68	45	3,6	1,65	53
 LDO	42STH40-2004MAH(VRN)	17	40	0,9	2	35	2,8	1,1	71
 LDO	42STH47-1684AC	17	48	1,8	1,68	49	2,8	1,65	68
 LDO	42STH47-2504AC	17	48	1,8	2,5	53,9	1,8	1,25	68
+LDO	42STH47-1206	17	48	1,8	1,2	31,1	2,8	3,3	68
+LDO	42STH47-0806	17	48	1,8	0,8	31,1	6,3	7,5	68
+LDO	42STH47-0406	17	48	1,8	0,4	31,1	25	30	68
 LDO	42STH48-1684MAH	17	48	0,9	1,68	39	2,8	1,65	68
 LDO	42STH48-2004AC(VRN)	17	48	1,8	2	59	3	1,6	85
 LDO	42STH48-2004AH	17	48	1,8	2	59	3	1,4	68
@@ -124,3 +143,5 @@ Usongshine	17HS4023	17	23	1,8	1	20	4,1	4,1	30,8
 Shengyang Motor	42BYGH3025-3M-25D	17	48	1,8	4	56	0,6	0,4	82	Sovol Zero A/B
 JUST MOTION CONTROL	28J1832-407-8-1510-01	11	32	1,8	0,75	6	4,6	4,7	18	5mm ID 8mm OD dualsided hollow shaft
 Honeybadger	Classified	17	60	1,8	2,85	88,3	2,3	1,1	102	Integrated thermistor;8mm shaft;Insulation Class F (155c)
+Longrunner/Zyltech	17HD48002H-22B	17	48	1,8	1,7	50	3,8	1,8	82  https://s3.devminer.xyz/archive/Zyltech_17HD48002H-22B.jpg
+Vexta	PK244-01A	17	41	1,8	1,2	33	12,8	6,6	54

--- a/src/lib/stepper-db.ts
+++ b/src/lib/stepper-db.ts
@@ -34,6 +34,54 @@ export const STEPPER_DB: Map<string, Map<string, StepperDefinition>> = new Map([
 				}
 			],
 			[
+				'BJ42D41-Y2V01',
+				{
+					brand: 'KeliMotor',
+					model: 'BJ42D41-Y2V01',
+					nemaSize: 17,
+					bodyLength: 59 as Millimeter,
+					stepAngle: 1.8 as Degree,
+					ratedCurrent: 1.5 as Ampere,
+					torque: 80 as NewtonCentimeter,
+					inductance: 6.9 as MilliHenry,
+					resistance: 3 as Ohm,
+					rotorInertia: 110 as GramSquareCentimeter,
+					comments: []
+				}
+			],
+			[
+				'BJ42D41-Y3V01',
+				{
+					brand: 'KeliMotor',
+					model: 'BJ42D41-Y3V01',
+					nemaSize: 17,
+					bodyLength: 59 as Millimeter,
+					stepAngle: 1.8 as Degree,
+					ratedCurrent: 2 as Ampere,
+					torque: 72 as NewtonCentimeter,
+					inductance: 3.7 as MilliHenry,
+					resistance: 1.8 as Ohm,
+					rotorInertia: 110 as GramSquareCentimeter,
+					comments: []
+				}
+			],
+			[
+				'BJ42D41-Y4V01',
+				{
+					brand: 'KeliMotor',
+					model: 'BJ42D41-Y4V01',
+					nemaSize: 17,
+					bodyLength: 59 as Millimeter,
+					stepAngle: 1.8 as Degree,
+					ratedCurrent: 2.5 as Ampere,
+					torque: 80 as NewtonCentimeter,
+					inductance: 2.4 as MilliHenry,
+					resistance: 1 as Ohm,
+					rotorInertia: 110 as GramSquareCentimeter,
+					comments: []
+				}
+			],
+			[
 				'BJ42D22-25V04',
 				{
 					brand: 'KeliMotor',
@@ -54,6 +102,22 @@ export const STEPPER_DB: Map<string, Map<string, StepperDefinition>> = new Map([
 				}
 			],
 			[
+				'BJ42D22-23V01',
+				{
+					brand: 'KeliMotor',
+					model: 'BJ42D22-23V01',
+					nemaSize: 17,
+					bodyLength: 40 as Millimeter,
+					stepAngle: 1.8 as Degree,
+					ratedCurrent: 1 as Ampere,
+					torque: 37 as NewtonCentimeter,
+					inductance: 6.9 as MilliHenry,
+					resistance: 2.8 as Ohm,
+					rotorInertia: 57 as GramSquareCentimeter,
+					comments: ['https://s3.devminer.xyz/archive/KeliMotor_BJ42D22-23V01.png']
+				}
+			],
+			[
 				'BJY36D12-04V28',
 				{
 					brand: 'KeliMotor',
@@ -70,6 +134,42 @@ export const STEPPER_DB: Map<string, Map<string, StepperDefinition>> = new Map([
 						'Preinstalled Involute 10T gear (0.5mm modulus, 20deg pressure angle)',
 						'ELEGOO Centauri Extruder',
 						'https://s3.devminer.xyz/archive/BJY36D12-04V28%20drawing.pdf'
+					]
+				}
+			],
+			[
+				'BJY36D12-04V01',
+				{
+					brand: 'KeliMotor',
+					model: 'BJY36D12-04V01',
+					nemaSize: 14,
+					bodyLength: 20.5 as Millimeter,
+					stepAngle: 1.8 as Degree,
+					ratedCurrent: 1 as Ampere,
+					torque: 11 as NewtonCentimeter,
+					inductance: 1.3 as MilliHenry,
+					resistance: 2 as Ohm,
+					rotorInertia: 17 as GramSquareCentimeter,
+					comments: ['Bambulab X1/P1 extruder', '9T helical gear']
+				}
+			],
+			[
+				'BJY36d13-01V01',
+				{
+					brand: 'KeliMotor',
+					model: 'BJY36d13-01V01',
+					nemaSize: 14,
+					bodyLength: 20 as Millimeter,
+					stepAngle: 1.8 as Degree,
+					ratedCurrent: 1 as Ampere,
+					torque: 19 as NewtonCentimeter,
+					inductance: 3.4 as MilliHenry,
+					resistance: 3.2 as Ohm,
+					rotorInertia: 11 as GramSquareCentimeter,
+					comments: [
+						'12T pinion gear',
+						'Creality K1 series extruder',
+						'https://s3.devminer.xyz/archive/Creativity_BJY36d13-01V01.webp'
 					]
 				}
 			],
@@ -138,10 +238,10 @@ export const STEPPER_DB: Map<string, Map<string, StepperDefinition>> = new Map([
 				}
 			],
 			[
-				'BJ42D15-26V12',
+				'BJ42D15-26V02',
 				{
 					brand: 'KeliMotor',
-					model: 'BJ42D15-26V12',
+					model: 'BJ42D15-26V02',
 					nemaSize: 17,
 					bodyLength: 34 as Millimeter,
 					stepAngle: 1.8 as Degree,
@@ -150,7 +250,77 @@ export const STEPPER_DB: Map<string, Map<string, StepperDefinition>> = new Map([
 					inductance: 8.8 as MilliHenry,
 					resistance: 6 as Ohm,
 					rotorInertia: 38 as GramSquareCentimeter,
+					comments: ['https://s3.devminer.xyz/archive/KeliMotor_BJ42D15-26V02%20drawing.pdf']
+				}
+			],
+			[
+				'BJ42D15-26V09',
+				{
+					brand: 'KeliMotor',
+					model: 'BJ42D15-26V09',
+					nemaSize: 17,
+					bodyLength: 34 as Millimeter,
+					stepAngle: 1.8 as Degree,
+					ratedCurrent: 0.84 as Ampere,
+					torque: 38 as NewtonCentimeter,
+					inductance: 8.8 as MilliHenry,
+					resistance: 6 as Ohm,
+					rotorInertia: 38 as GramSquareCentimeter,
+					comments: [
+						'Apparently identical to BJ42D16-26V09',
+						'https://s3.devminer.xyz/archive/KeliMotor_BJ42D15-26V09.png'
+					]
+				}
+			],
+			[
+				'BJ42D15-26V10',
+				{
+					brand: 'KeliMotor',
+					model: 'BJ42D15-26V10',
+					nemaSize: 17,
+					bodyLength: 34 as Millimeter,
+					stepAngle: 1.8 as Degree,
+					ratedCurrent: 0.84 as Ampere,
+					torque: 28 as NewtonCentimeter,
+					inductance: 8.8 as MilliHenry,
+					resistance: 6 as Ohm,
+					rotorInertia: 38 as GramSquareCentimeter,
+					comments: [
+						'Preinstalled with GT2 pulley',
+						'https://s3.devminer.xyz/archive/KeliMotor_BJ42D15-26V10.pdf'
+					]
+				}
+			],
+			[
+				'BJ42D15-26V12',
+				{
+					brand: 'KeliMotor',
+					model: 'BJ42D15-26V12',
+					nemaSize: 17,
+					bodyLength: 34 as Millimeter,
+					stepAngle: 1.8 as Degree,
+					ratedCurrent: 0.84 as Ampere,
+					torque: 38 as NewtonCentimeter,
+					inductance: 8.8 as MilliHenry,
+					resistance: 6 as Ohm,
+					rotorInertia: 38 as GramSquareCentimeter,
 					comments: ['Ender 3 S1 (and more, probably)']
+				}
+			],
+			[
+				'BJ42D16-26V09',
+				{
+					brand: 'KeliMotor',
+					model: 'BJ42D16-26V09',
+					nemaSize: 17,
+					bodyLength: 34 as Millimeter,
+					stepAngle: 1.8 as Degree,
+					ratedCurrent: 0.84 as Ampere,
+					torque: 38 as NewtonCentimeter,
+					inductance: 8.8 as MilliHenry,
+					resistance: 6 as Ohm,
+					rotorInertia: 57 as GramSquareCentimeter,
+					comments: ['Apparently identical to BJ42D15-26V09']
 				}
 			],
 			[
@@ -192,6 +362,52 @@ export const STEPPER_DB: Map<string, Map<string, StepperDefinition>> = new Map([
 		])
 	],
 	[
+		'Creativity',
+		new Map<string, StepperDefinition>([
+			[
+				'BJ42D29-100V02',
+				{
+					brand: 'Creativity',
+					model: 'BJ42D29-100V02',
+					nemaSize: 14,
+					bodyLength: 20 as Millimeter,
+					stepAngle: 1.8 as Degree,
+					ratedCurrent: 1 as Ampere,
+					torque: 12 as NewtonCentimeter,
+					inductance: 1 as MilliHenry,
+					resistance: 2.3 as Ohm,
+					rotorInertia: 16 as GramSquareCentimeter,
+					comments: [
+						'Bambulab X1/P1 extruder replacement',
+						'9T helical gear',
+						'most motors with four screws in the front plate appear to be this model'
+					]
+				}
+			]
+		])
+	],
+	[
+		'Twotrees',
+		new Map<string, StepperDefinition>([
+			[
+				'36STH20-1004HG',
+				{
+					brand: 'Twotrees',
+					model: '36STH20-1004HG',
+					nemaSize: 14,
+					bodyLength: 22 as Millimeter,
+					stepAngle: 1.8 as Degree,
+					ratedCurrent: 1 as Ampere,
+					torque: 10 as NewtonCentimeter,
+					inductance: 1.6 as MilliHenry,
+					resistance: 2.1 as Ohm,
+					rotorInertia: 16 as GramSquareCentimeter,
+					comments: ['Sketchy motor sold for VORONS with similar P/N to LDO 36STH20-1004(A/HG)']
+				}
+			]
+		])
+	],
+	[
 		'ACT',
 		new Map<string, StepperDefinition>([
 			[
@@ -223,7 +439,7 @@ export const STEPPER_DB: Map<string, Map<string, StepperDefinition>> = new Map([
 					inductance: 1.75 as MilliHenry,
 					resistance: 1 as Ohm,
 					rotorInertia: 68 as GramSquareCentimeter,
-					comments: []
+					comments: ['Seem to be clones/rebadges of Wantai 42BYGHW811-06']
 				}
 			],
 			[
@@ -516,6 +732,61 @@ export const STEPPER_DB: Map<string, Map<string, StepperDefinition>> = new Map([
 					rotorInertia: 110 as GramSquareCentimeter,
 					comments: []
 				}
+			],
+			[
+				'36HS20HM-1884A',
+				{
+					brand: 'ACT',
+					model: '36HS20HM-1884A',
+					nemaSize: 14,
+					bodyLength: 19 as Millimeter,
+					stepAngle: 1.8 as Degree,
+					ratedCurrent: 1.88 as Ampere,
+					torque: 13 as NewtonCentimeter,
+					inductance: 1.05 as MilliHenry,
+					resistance: 1.85 as Ohm,
+					rotorInertia: 6 as GramSquareCentimeter,
+					comments: [
+						'often sold in VORON extruder kits',
+						'may be identified as 36HS2418CL16, or 36HS2418CL6',
+						'https://s3.devminer.xyz/archive/Maccurat_36HS20HM-1884A.avif'
+					]
+				}
+			],
+			[
+				'36BYG1204-A-6QHT',
+				{
+					brand: 'ACT',
+					model: '36BYG1204-A-6QHT',
+					nemaSize: 14,
+					bodyLength: 22 as Millimeter,
+					stepAngle: 1.8 as Degree,
+					ratedCurrent: 0.5 as Ampere,
+					torque: 12 as NewtonCentimeter,
+					inductance: 1 as MilliHenry,
+					resistance: 1.3 as Ohm,
+					rotorInertia: 15 as GramSquareCentimeter,
+					comments: [
+						'often sold in VORON extruder kits',
+						'https://s3.devminer.xyz/archive/ACT_36BYG1204-A-6QHT.webp'
+					]
+				}
+			],
+			[
+				'36BYG1103-3M-8QH',
+				{
+					brand: 'ACT',
+					model: '36BYG1103-3M-8QH',
+					nemaSize: 14,
+					bodyLength: 20 as Millimeter,
+					stepAngle: 1.8 as Degree,
+					ratedCurrent: 1 as Ampere,
+					torque: 11 as NewtonCentimeter,
+					inductance: 1 as MilliHenry,
+					resistance: 1.3 as Ohm,
+					rotorInertia: 17 as GramSquareCentimeter,
+					comments: []
+				}
 			]
 		])
 	],
@@ -568,6 +839,26 @@ export const STEPPER_DB: Map<string, Map<string, StepperDefinition>> = new Map([
 					resistance: 13 as Ohm,
 					rotorInertia: 15 as GramSquareCentimeter,
 					comments: []
+				}
+			],
+			[
+				'G36HSY4405-6DB-1000A',
+				{
+					brand: 'FYSETC',
+					model: 'G36HSY4405-6DB-1000A',
+					nemaSize: 14,
+					bodyLength: 20.5 as Millimeter,
+					stepAngle: 1.8 as Degree,
+					ratedCurrent: 1 as Ampere,
+					torque: 11 as NewtonCentimeter,
+					inductance: 1.7 as MilliHenry,
+					resistance: 2.4 as Ohm,
+					rotorInertia: 15 as GramSquareCentimeter,
+					comments: [
+						'Appears to ship with IdeaFormer space V2 extruder, likely others',
+						'not labelled as FYSETC but likely is',
+						'https://s3.devminer.xyz/archive/FYSETC_G36HSY4405-6DB-1000A.webp'
+					]
 				}
 			],
 			[
@@ -976,6 +1267,54 @@ export const STEPPER_DB: Map<string, Map<string, StepperDefinition>> = new Map([
 					torque: 53.9 as NewtonCentimeter,
 					inductance: 1.8 as MilliHenry,
 					resistance: 1.25 as Ohm,
+					rotorInertia: 68 as GramSquareCentimeter,
+					comments: []
+				}
+			],
+			[
+				'42STH47-1206',
+				{
+					brand: 'LDO',
+					model: '42STH47-1206',
+					nemaSize: 17,
+					bodyLength: 48 as Millimeter,
+					stepAngle: 1.8 as Degree,
+					ratedCurrent: 1.2 as Ampere,
+					torque: 31.1 as NewtonCentimeter,
+					inductance: 2.8 as MilliHenry,
+					resistance: 3.3 as Ohm,
+					rotorInertia: 68 as GramSquareCentimeter,
+					comments: []
+				}
+			],
+			[
+				'42STH47-0806',
+				{
+					brand: 'LDO',
+					model: '42STH47-0806',
+					nemaSize: 17,
+					bodyLength: 48 as Millimeter,
+					stepAngle: 1.8 as Degree,
+					ratedCurrent: 0.8 as Ampere,
+					torque: 31.1 as NewtonCentimeter,
+					inductance: 6.3 as MilliHenry,
+					resistance: 7.5 as Ohm,
+					rotorInertia: 68 as GramSquareCentimeter,
+					comments: []
+				}
+			],
+			[
+				'42STH47-0406',
+				{
+					brand: 'LDO',
+					model: '42STH47-0406',
+					nemaSize: 17,
+					bodyLength: 48 as Millimeter,
+					stepAngle: 1.8 as Degree,
+					ratedCurrent: 0.4 as Ampere,
+					torque: 31.1 as NewtonCentimeter,
+					inductance: 25 as MilliHenry,
+					resistance: 30 as Ohm,
 					rotorInertia: 68 as GramSquareCentimeter,
 					comments: []
 				}
@@ -1498,6 +1837,22 @@ export const STEPPER_DB: Map<string, Map<string, StepperDefinition>> = new Map([
 				}
 			],
 			[
+				'MS17HDBP4100',
+				{
+					brand: 'Moons',
+					model: 'MS17HDBP4100',
+					nemaSize: 17,
+					bodyLength: 63 as Millimeter,
+					stepAngle: 1.8 as Degree,
+					ratedCurrent: 1 as Ampere,
+					torque: 82 as NewtonCentimeter,
+					inductance: 14.6 as MilliHenry,
+					resistance: 5.6 as Ohm,
+					rotorInertia: 123 as GramSquareCentimeter,
+					comments: []
+				}
+			],
+			[
 				'MS17HA2P4150',
 				{
 					brand: 'Moons',
@@ -1530,18 +1885,18 @@ export const STEPPER_DB: Map<string, Map<string, StepperDefinition>> = new Map([
 				}
 			],
 			[
-				'MS17HDBP4100',
+				'MS17HD6P4200',
 				{
 					brand: 'Moons',
-					model: 'MS17HDBP4100',
+					model: 'MS17HD6P4200',
 					nemaSize: 17,
-					bodyLength: 63 as Millimeter,
+					bodyLength: 48.3 as Millimeter,
 					stepAngle: 1.8 as Degree,
-					ratedCurrent: 1 as Ampere,
-					torque: 82 as NewtonCentimeter,
-					inductance: 14.6 as MilliHenry,
-					resistance: 5.6 as Ohm,
-					rotorInertia: 123 as GramSquareCentimeter,
+					ratedCurrent: 2 as Ampere,
+					torque: 63 as NewtonCentimeter,
+					inductance: 1.3 as MilliHenry,
+					resistance: 2.9 as Ohm,
+					rotorInertia: 82 as GramSquareCentimeter,
 					comments: []
 				}
 			],
@@ -1575,6 +1930,22 @@ export const STEPPER_DB: Map<string, Map<string, StepperDefinition>> = new Map([
 					resistance: 1.3 as Ohm,
 					rotorInertia: 82 as GramSquareCentimeter,
 					comments: ['Formbot VORON2.4 kit A/B & Z']
+				}
+			],
+			[
+				'MS17HDBP4200',
+				{
+					brand: 'Moons',
+					model: 'MS17HDBP4200',
+					nemaSize: 17,
+					bodyLength: 62.8 as Millimeter,
+					stepAngle: 1.8 as Degree,
+					ratedCurrent: 2 as Ampere,
+					torque: 83 as NewtonCentimeter,
+					inductance: 3.8 as MilliHenry,
+					resistance: 1.49 as Ohm,
+					rotorInertia: 123 as GramSquareCentimeter,
+					comments: []
 				}
 			],
 			[
@@ -2758,6 +3129,48 @@ export const STEPPER_DB: Map<string, Map<string, StepperDefinition>> = new Map([
 					resistance: 1.1 as Ohm,
 					rotorInertia: 102 as GramSquareCentimeter,
 					comments: ['Integrated thermistor', '8mm shaft', 'Insulation Class F (155c)']
+				}
+			]
+		])
+	],
+	[
+		'Longrunner/Zyltech',
+		new Map<string, StepperDefinition>([
+			[
+				'17HD48002H-22B',
+				{
+					brand: 'Longrunner/Zyltech',
+					model: '17HD48002H-22B',
+					nemaSize: 17,
+					bodyLength: 48 as Millimeter,
+					stepAngle: 1.8 as Degree,
+					ratedCurrent: 1.7 as Ampere,
+					torque: 50 as NewtonCentimeter,
+					inductance: 3.8 as MilliHenry,
+					resistance: 1.8 as Ohm,
+					rotorInertia: 82 as GramSquareCentimeter,
+					comments: []
+				}
+			]
+		])
+	],
+	[
+		'Vexta',
+		new Map<string, StepperDefinition>([
+			[
+				'PK244-01A',
+				{
+					brand: 'Vexta',
+					model: 'PK244-01A',
+					nemaSize: 17,
+					bodyLength: 41 as Millimeter,
+					stepAngle: 1.8 as Degree,
+					ratedCurrent: 1.2 as Ampere,
+					torque: 33 as NewtonCentimeter,
+					inductance: 12.8 as MilliHenry,
+					resistance: 6.6 as Ohm,
+					rotorInertia: 54 as GramSquareCentimeter,
+					comments: []
 				}
 			]
 		])


### PR DESCRIPTION
I had an error while updating the database that was resolved by changing syntax in line 6 of the csv converter. Steppers are from various sources online, additionally I located a larger database of fysetc motor datasheets at https://github.com/FYSETC/FYSETC-MOTORS that may be of interest and are not included here.